### PR TITLE
Implements testing on API prefix feature.

### DIFF
--- a/tests/Feature/ApiPrefixTest.php
+++ b/tests/Feature/ApiPrefixTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ApiPrefixTest extends TestCase
+{
+    public function test_routes_includes_api_prefix(): void
+    {
+        $this->assertTrue(Str::contains(route('api::v1::admin::login'), '/api/v1'));
+        $this->assertTrue(Str::contains(route('api::v1::admin::user-listing'), '/api/v1'));
+    }
+}


### PR DESCRIPTION
The API routing prefix must follow the following convention: /api/v1/{route_name}

For example:

https://{{base_url}}/api/v1/admin/login

https://{{base_url}}/api/v1/products